### PR TITLE
feat: add talk CLI command for AI-powered claim rendering

### DIFF
--- a/cmd/talk.go
+++ b/cmd/talk.go
@@ -1,0 +1,225 @@
+// Package cmd provides the command-line interface for generating configurations using AI.
+//
+// Copyright © 2025 PATRICK HERMANN
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/charmbracelet/huh/spinner"
+	"github.com/spf13/cobra"
+	"github.com/stuttgart-things/k2n/internal"
+	"github.com/stuttgart-things/k2n/internal/ai"
+	"github.com/stuttgart-things/k2n/internal/talk"
+)
+
+var (
+	talkAPIURL      string
+	talkAuthToken   string
+	talkInstruction string
+	talkDestination string
+	talkProvider    string
+	talkModel       string
+	talkBaseURL     string
+	talkVerbose     bool
+)
+
+var talkCmd = &cobra.Command{
+	Use:   "talk",
+	Short: "AI-powered conversation for rendering Crossplane claims via claim-machinery-api",
+	Long: `The 'talk' command connects to a running claim-machinery-api instance,
+discovers available claim templates, and uses AI to match your natural language
+request to the right template and parameters. The result is a rendered Crossplane
+claim in YAML format.`,
+	Run: func(cmd *cobra.Command, args []string) {
+		internal.PrintBanner()
+
+		// Validate API URL
+		if talkAPIURL == "" {
+			talkAPIURL = os.Getenv("CLAIM_API_URL")
+		}
+		if talkAPIURL == "" {
+			fmt.Fprintln(os.Stderr, "Error: --api-url or CLAIM_API_URL is required")
+			os.Exit(1)
+		}
+
+		// Validate instruction
+		if talkInstruction == "" {
+			fmt.Fprintln(os.Stderr, "Error: --instruction is required")
+			os.Exit(1)
+		}
+
+		// Read API key
+		apiKey := os.Getenv(envAPIKeyVar)
+		if apiKey == "" {
+			fmt.Fprintln(os.Stderr, "Error: AI_API_KEY environment variable is required")
+			os.Exit(1)
+		}
+
+		// Auth token for claim-machinery-api
+		if talkAuthToken == "" {
+			talkAuthToken = os.Getenv("CLAIM_API_TOKEN")
+		}
+
+		// Setup AI provider
+		providerConfig := &ai.ProviderConfig{APIKey: apiKey}
+		if talkProvider != "" {
+			providerConfig.Type = ai.ProviderType(talkProvider)
+		} else if envProvider := os.Getenv("AI_PROVIDER"); envProvider != "" {
+			providerConfig.Type = ai.ProviderType(envProvider)
+		} else {
+			providerConfig.Type = ai.ProviderOpenRouter
+		}
+
+		switch providerConfig.Type {
+		case ai.ProviderOpenRouter:
+			if talkModel != "" {
+				providerConfig.Model = talkModel
+			} else if envModel := os.Getenv("AI_MODEL"); envModel != "" {
+				providerConfig.Model = envModel
+			} else {
+				providerConfig.Model = "openai/gpt-3.5-turbo"
+			}
+			if talkBaseURL != "" {
+				providerConfig.BaseURL = talkBaseURL
+			} else if envURL := os.Getenv("AI_BASE_URL"); envURL != "" {
+				providerConfig.BaseURL = envURL
+			} else {
+				providerConfig.BaseURL = "https://openrouter.ai/api/v1/chat/completions"
+			}
+		case ai.ProviderGemini:
+			// No additional config needed
+		}
+
+		// Print config
+		internal.PrintEnvTable(map[string]string{
+			"CLAIM_API_URL": talkAPIURL,
+			"AI_PROVIDER":   string(providerConfig.Type),
+			"AI_MODEL":      providerConfig.Model,
+			"INSTRUCTION":   talkInstruction,
+			"DESTINATION":   talkDestination,
+		})
+
+		// Step 1: Fetch templates from claim-machinery-api
+		client := talk.NewClient(talkAPIURL, talkAuthToken)
+
+		var templates []talk.ClaimTemplate
+		fmt.Println()
+		ctx1, cancel1 := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel1()
+		if err := spinner.New().
+			Context(ctx1).
+			Title("Fetching claim templates...").
+			Action(func() {
+				var fetchErr error
+				templates, fetchErr = client.ListTemplates()
+				if fetchErr != nil {
+					fmt.Fprintf(os.Stderr, "\nError fetching templates: %v\n", fetchErr)
+					os.Exit(1)
+				}
+			}).Run(); err != nil {
+			fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+			os.Exit(1)
+		}
+
+		if len(templates) == 0 {
+			fmt.Println("No claim templates found on the API.")
+			return
+		}
+		fmt.Printf("Found %d claim template(s)\n\n", len(templates))
+
+		// Step 2: Build prompt and call AI
+		systemPrompt := talk.BuildSystemPrompt(templates)
+		fullPrompt := talk.BuildUserPrompt(systemPrompt, talkInstruction)
+
+		if talkVerbose {
+			fmt.Println("--- PROMPT ---")
+			fmt.Println(fullPrompt)
+			fmt.Println("--- END PROMPT ---\n")
+		}
+
+		var aiOutput string
+		ctx2, cancel2 := context.WithTimeout(context.Background(), 2*time.Minute)
+		defer cancel2()
+		if err := spinner.New().
+			Context(ctx2).
+			Title(fmt.Sprintf("Asking %s AI to select template and parameters...", string(providerConfig.Type))).
+			Action(func() {
+				var callErr error
+				aiOutput, callErr = ai.CallAI(providerConfig, fullPrompt)
+				if callErr != nil {
+					fmt.Fprintf(os.Stderr, "\nError calling AI: %v\n", callErr)
+					os.Exit(1)
+				}
+			}).Run(); err != nil {
+			fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+			os.Exit(1)
+		}
+
+		if talkVerbose {
+			fmt.Println("--- AI RESPONSE ---")
+			fmt.Println(aiOutput)
+			fmt.Println("--- END AI RESPONSE ---\n")
+		}
+
+		// Step 3: Parse AI response
+		aiResp, parseErr := talk.ParseAIResponse(aiOutput)
+		if parseErr != nil {
+			fmt.Fprintf(os.Stderr, "Error parsing AI response: %v\n", parseErr)
+			os.Exit(1)
+		}
+
+		if aiResp.TemplateName == "" {
+			fmt.Printf("AI could not match your request to a template.\nReason: %s\n", aiResp.Explanation)
+			return
+		}
+
+		fmt.Printf("Selected template: %s\n", aiResp.TemplateName)
+		fmt.Printf("Explanation: %s\n", aiResp.Explanation)
+		if talkVerbose {
+			fmt.Printf("Parameters: %v\n", aiResp.Parameters)
+		}
+		fmt.Println()
+
+		// Step 4: Order the claim
+		var orderResp *talk.OrderResponse
+		ctx3, cancel3 := context.WithTimeout(context.Background(), 60*time.Second)
+		defer cancel3()
+		if err := spinner.New().
+			Context(ctx3).
+			Title("Rendering claim via claim-machinery-api...").
+			Action(func() {
+				var orderErr error
+				orderResp, orderErr = client.OrderClaim(aiResp.TemplateName, aiResp.Parameters, "k2n-talk")
+				if orderErr != nil {
+					fmt.Fprintf(os.Stderr, "\nError ordering claim: %v\n", orderErr)
+					os.Exit(1)
+				}
+			}).Run(); err != nil {
+			fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+			os.Exit(1)
+		}
+
+		// Step 5: Output the rendered YAML
+		fmt.Println("Claim rendered successfully!\n")
+		if err := internal.SaveOutput(talkDestination, orderResp.Rendered); err != nil {
+			fmt.Fprintf(os.Stderr, "Error saving output: %v\n", err)
+			os.Exit(1)
+		}
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(talkCmd)
+	talkCmd.Flags().StringVar(&talkAPIURL, "api-url", "", "Base URL of the claim-machinery-api (or CLAIM_API_URL env var)")
+	talkCmd.Flags().StringVar(&talkAuthToken, "api-token", "", "Auth token for claim-machinery-api (or CLAIM_API_TOKEN env var)")
+	talkCmd.Flags().StringVar(&talkInstruction, "instruction", "", "Natural language description of the claim you want")
+	talkCmd.Flags().StringVar(&talkDestination, "destination", "", "Output destination: stdout (default), file path, or directory")
+	talkCmd.Flags().StringVar(&talkProvider, "ai-provider", "", "AI provider: openrouter or gemini (default from AI_PROVIDER env)")
+	talkCmd.Flags().StringVar(&talkModel, "ai-model", "", "AI model name (default from AI_MODEL env)")
+	talkCmd.Flags().StringVar(&talkBaseURL, "ai-base-url", "", "Base URL for OpenRouter API (default from AI_BASE_URL env)")
+	talkCmd.Flags().BoolVarP(&talkVerbose, "verbose", "v", false, "Enable verbose output (show prompts and raw AI responses)")
+}

--- a/internal/menu/interactive.go
+++ b/internal/menu/interactive.go
@@ -22,6 +22,9 @@ type K2NConfig struct {
 	AIModel             string
 	Verbose             bool
 	PromptToAI          bool
+	// Talk-specific fields
+	TalkAPIURL    string
+	TalkAPIToken  string
 }
 
 // ShowInteractiveMenu displays the main menu when k2n is run without arguments
@@ -48,6 +51,14 @@ func ShowInteractiveMenu(rootCmd *cobra.Command) error {
 				return err
 			}
 			return nil
+		case "talk":
+			if err := showTalkMenu(config); err != nil {
+				return err
+			}
+			if err := showTalkExecutionConfirmation(config, rootCmd); err != nil {
+				return err
+			}
+			return nil
 		case "help":
 			rootCmd.Help()
 			return nil
@@ -66,6 +77,7 @@ func showMainMenu(config *K2NConfig) error {
 				Description("What would you like to do?").
 				Options(
 					huh.NewOption("🎨 Generate Code (gen)", "gen"),
+					huh.NewOption("💬 Talk to Claims API (talk)", "talk"),
 					huh.NewOption("❓ Show Help", "help"),
 					huh.NewOption("🚪 Exit", "exit"),
 				).
@@ -362,4 +374,120 @@ func getEnvOrDefault(key, defaultValue string) string {
 		return val
 	}
 	return defaultValue
+}
+
+func showTalkMenu(config *K2NConfig) error {
+	config.TalkAPIURL = getEnvOrDefault("CLAIM_API_URL", "")
+	config.TalkAPIToken = getEnvOrDefault("CLAIM_API_TOKEN", "")
+
+	fmt.Println("\n💬 Talk to Claims API")
+	fmt.Println(strings.Repeat("─", 50))
+
+	if err := huh.NewForm(
+		huh.NewGroup(
+			huh.NewInput().
+				Title("Claim Machinery API URL").
+				Description("Base URL of the running claim-machinery-api").
+				Placeholder("http://localhost:8080").
+				Validate(func(s string) error {
+					if len(s) == 0 {
+						return fmt.Errorf("API URL is required")
+					}
+					return nil
+				}).
+				Value(&config.TalkAPIURL),
+
+			huh.NewText().
+				Title("Instruction").
+				Description("Describe in natural language what claim you want").
+				Placeholder("I need a 50Gi persistent volume in namespace production...").
+				CharLimit(500).
+				Validate(func(s string) error {
+					if len(s) == 0 {
+						return fmt.Errorf("instruction is required")
+					}
+					return nil
+				}).
+				Value(&config.Instruction),
+
+			huh.NewSelect[string]().
+				Title("Destination").
+				Description("Where should the rendered claim go?").
+				Options(
+					huh.NewOption("📺 Standard Output (stdout)", ""),
+					huh.NewOption("📄 Single File", "file"),
+					huh.NewOption("📁 Directory (separate files)", "directory"),
+				).
+				Value(&config.Destination),
+		),
+	).WithTheme(huh.ThemeCharm()).Run(); err != nil {
+		return err
+	}
+
+	// AI config reuse
+	return showAIConfig(config)
+}
+
+func showTalkExecutionConfirmation(config *K2NConfig, rootCmd *cobra.Command) error {
+	fmt.Println("\n" + strings.Repeat("═", 70))
+	fmt.Println("💬 Talk Command Summary")
+	fmt.Println(strings.Repeat("═", 70))
+
+	args := buildTalkCommandArgs(config)
+	cmdString := "k2n talk " + strings.Join(args, " ")
+
+	fmt.Println("\n🔧 Generated Command:")
+	fmt.Println("  " + cmdString)
+
+	fmt.Println("\n📊 Configuration:")
+	fmt.Printf("  API URL:         %s\n", config.TalkAPIURL)
+	fmt.Printf("  Instruction:     %s\n", truncate(config.Instruction, 50))
+	fmt.Printf("  Destination:     %s\n", getOrEmpty(config.Destination))
+	fmt.Printf("  AI Provider:     %s\n", config.AIProvider)
+	fmt.Printf("  AI Model:        %s\n", getOrEmpty(config.AIModel))
+	fmt.Println(strings.Repeat("═", 70))
+
+	var execute bool
+	if err := huh.NewConfirm().
+		Title("Execute this command?").
+		Affirmative("Yes, run it!").
+		Negative("No, exit").
+		Value(&execute).
+		Run(); err != nil {
+		return err
+	}
+
+	if execute {
+		fmt.Println("\n🚀 Executing command...\n")
+		os.Args = append([]string{"k2n", "talk"}, args...)
+		return rootCmd.Execute()
+	}
+
+	fmt.Println("\n👋 Command not executed. Goodbye!")
+	return nil
+}
+
+func buildTalkCommandArgs(config *K2NConfig) []string {
+	var args []string
+
+	if config.TalkAPIURL != "" {
+		args = append(args, "--api-url", config.TalkAPIURL)
+	}
+	if config.Instruction != "" {
+		args = append(args, "--instruction", fmt.Sprintf("%q", config.Instruction))
+	}
+	if config.Destination != "" {
+		args = append(args, "--destination", config.Destination)
+	}
+	if config.AIProvider != "" && config.AIProvider != "gemini" {
+		args = append(args, "--ai-provider", config.AIProvider)
+	}
+	if config.AIModel != "" {
+		args = append(args, "--ai-model", config.AIModel)
+	}
+	if config.TalkAPIToken != "" {
+		args = append(args, "--api-token", config.TalkAPIToken)
+	}
+
+	return args
 }


### PR DESCRIPTION
## Summary
- Add `k2n talk` command that connects to claim-machinery-api and renders claims via AI
- Workflow: fetch templates -> AI selects template + fills parameters -> order claim -> output YAML
- Supports `--api-url`, `--instruction`, `--destination`, `--ai-provider`, `--ai-model`, `--verbose` flags
- Integrates "Talk to Claims API" option into the interactive menu

Closes #24

## Test plan
- [ ] Verify `go build ./...` succeeds
- [ ] Verify `k2n talk --help` shows all flags
- [ ] Test against running claim-machinery-api with `k2n talk --api-url http://localhost:8080 --instruction "I need a volume claim"`
- [ ] Verify interactive menu shows "Talk to Claims API" option

🤖 Generated with [Claude Code](https://claude.com/claude-code)