### PR TITLE
docs: add mkdocs documentation, catalog-info, and update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,14 @@
 # /ˈkæf.kən/ (k2n)
 
-kaeffken, or in short k2n (/keɪ tuː ɛn/ ) is a cli for generating ai based claims or inlcude statements. The generation is based on examples and rulesets. claims are user-facing Kubernetes custom resources (CRDs) that allow application teams (developers, workloads) to request infrastructure or services without knowing the underlying implementation details
+kaeffken, or in short k2n (/keɪ tuː ɛn/ ) is a cli for generating ai based claims or include statements. The generation is based on examples and rulesets. claims are user-facing Kubernetes custom resources (CRDs) that allow application teams (developers, workloads) to request infrastructure or services without knowing the underlying implementation details.
+
+## FEATURES
+
+- AI-powered code/claim generation from examples and rulesets (`gen`)
+- AI-powered conversational claim rendering via claim-machinery-api (`talk`)
+- Support for multiple AI providers (OpenRouter, Gemini)
+- Interactive TUI menu for guided configuration
+- Output to stdout, file, or directory
 
 ## DEV
 
@@ -17,6 +25,8 @@ task go-lint:lint-go-interactive
 </details>
 
 ## USAGE-EXAMPLES
+
+### AI Provider Configuration
 
 <details><summary>OPENROUTER</summary>
 
@@ -39,6 +49,7 @@ export AI_API_KEY="your-gemini-api-key" # pragma: allowlist secret
 
 </details>
 
+### Gen Command
 
 <details><summary>VERBOSE OUTPUT OF THE PROMPT (w/o SENDING IT)</summary>
 
@@ -86,6 +97,49 @@ k2n gen \
 
 </details>
 
+### Talk Command
+
+<details><summary>TALK TO CLAIM-MACHINERY-API (OPENROUTER)</summary>
+
+```bash
+export AI_PROVIDER="openrouter"
+export AI_MODEL="openai/gpt-4"
+export AI_API_KEY="sk-or.." # pragma: allowlist secret
+
+k2n talk \
+--api-url http://localhost:8080 \
+--instruction "I need a 50Gi persistent volume in namespace production with fast-ssd storage class"
+```
+
+</details>
+
+<details><summary>TALK TO CLAIM-MACHINERY-API (GEMINI)</summary>
+
+```bash
+export AI_PROVIDER="gemini"
+export AI_API_KEY="your-gemini-api-key" # pragma: allowlist secret
+
+k2n talk \
+--api-url http://localhost:8080 \
+--instruction "create a harbor project for team-alpha" \
+--destination /tmp/claim.yaml \
+--verbose
+```
+
+</details>
+
+<details><summary>TALK WITH ENV VARS</summary>
+
+```bash
+export AI_PROVIDER="openrouter"
+export AI_MODEL="deepseek/deepseek-r1-0528:free"
+export AI_API_KEY="sk-or.." # pragma: allowlist secret
+export CLAIM_API_URL="http://localhost:8080"
+
+k2n talk --instruction "give me a vsphere vm with 4 cpus and 8gb ram"
+```
+
+</details>
 
 ## AUTHOR
 

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -1,0 +1,28 @@
+---
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: k2n
+  description: AI-powered CLI for generating Kubernetes and infrastructure configurations from examples and rulesets
+  annotations:
+    github.com/project-slug: stuttgart-things/k2n
+    backstage.io/techdocs-ref: url:https://github.com/stuttgart-things/k2n/tree/main
+    backstage.io/source-location: url:https://github.com/stuttgart-things/k2n
+  tags:
+    - cli
+    - ai
+    - kubernetes
+    - crossplane
+    - claims
+    - golang
+  links:
+    - url: https://github.com/stuttgart-things/k2n
+      title: GitHub Repository
+      icon: github
+spec:
+  type: tool
+  lifecycle: production
+  owner: platform-team
+  system: platform-engineering
+  dependsOn:
+    - component:claim-machinery-api

--- a/docs/ai-providers.md
+++ b/docs/ai-providers.md
@@ -1,0 +1,71 @@
+# AI Providers
+
+k2n supports multiple AI providers through a pluggable provider architecture. Both the `gen` and `talk` commands use the same provider configuration.
+
+## OpenRouter
+
+[OpenRouter](https://openrouter.ai/) provides access to multiple AI models through a unified API.
+
+### Configuration
+
+```bash
+export AI_PROVIDER="openrouter"
+export AI_API_KEY="sk-or-..."
+export AI_MODEL="openai/gpt-4"                                    # optional, default: openai/gpt-3.5-turbo
+export AI_BASE_URL="https://openrouter.ai/api/v1/chat/completions" # optional, this is the default
+```
+
+Or via CLI flags:
+
+```bash
+k2n gen --ai-provider openrouter --ai-model "openai/gpt-4" ...
+k2n talk --ai-provider openrouter --ai-model "openai/gpt-4" ...
+```
+
+### Supported Models
+
+Any model available on OpenRouter can be used. Some popular options:
+
+| Model | ID | Notes |
+|-------|----|-------|
+| GPT-4 | `openai/gpt-4` | High quality |
+| GPT-3.5 Turbo | `openai/gpt-3.5-turbo` | Default, fast |
+| Deepseek R1 | `deepseek/deepseek-r1-0528:free` | Free tier |
+
+### Custom Base URL
+
+For enterprise deployments or self-hosted OpenRouter-compatible endpoints:
+
+```bash
+export AI_BASE_URL="https://your-internal-endpoint/v1/chat/completions"
+```
+
+## Google Gemini
+
+Google's [Gemini](https://ai.google.dev/) API for generative AI.
+
+### Configuration
+
+```bash
+export AI_PROVIDER="gemini"
+export AI_API_KEY="your-gemini-api-key"
+```
+
+Or via CLI flags:
+
+```bash
+k2n gen --ai-provider gemini ...
+k2n talk --ai-provider gemini ...
+```
+
+### Model
+
+k2n uses the `gemini-3-pro-preview` model by default. No additional model configuration is needed.
+
+## Priority Order
+
+Configuration is resolved in this order (highest priority first):
+
+1. CLI flags (`--ai-provider`, `--ai-model`, `--ai-base-url`)
+2. Environment variables (`AI_PROVIDER`, `AI_MODEL`, `AI_BASE_URL`)
+3. Default values (provider: `openrouter`, model: `openai/gpt-3.5-turbo`)

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,83 @@
+# Architecture
+
+## Project Structure
+
+```
+k2n/
+├── main.go                       # Entry point
+├── cmd/
+│   ├── root.go                   # Root command, interactive menu
+│   ├── gen.go                    # Gen command
+│   ├── talk.go                   # Talk command
+│   └── version.go                # Version command
+├── internal/
+│   ├── ai/
+│   │   ├── provider.go           # Provider abstraction and factory
+│   │   ├── gemini.go             # Google Gemini implementation
+│   │   └── openrouter.go         # OpenRouter implementation
+│   ├── menu/
+│   │   └── interactive.go        # Interactive TUI menu
+│   ├── talk/
+│   │   ├── client.go             # claim-machinery-api HTTP client
+│   │   └── conversation.go       # AI conversation logic and prompt building
+│   ├── examples.go               # Example file loading
+│   ├── ruleset.go                # Ruleset loading
+│   ├── prompt.go                 # Prompt construction for gen
+│   ├── output.go                 # Output handling (stdout, file, directory)
+│   └── print.go                  # Terminal UI (banner, tables)
+├── _examples/                    # Example files and rulesets
+├── docs/                         # MkDocs documentation
+├── catalog-info.yaml             # Backstage catalog entry
+└── mkdocs.yml                    # MkDocs configuration
+```
+
+## Component Overview
+
+### CLI Layer (`cmd/`)
+
+Built with [Cobra](https://github.com/spf13/cobra). Handles flag parsing, environment variable resolution, and orchestrates the workflow for each command.
+
+### AI Provider Layer (`internal/ai/`)
+
+Pluggable provider architecture with a common `AIProvider` interface:
+
+```go
+type AIProvider interface {
+    Call(apiKey, prompt string) (string, error)
+}
+```
+
+New providers can be added by implementing this interface and registering them in the factory.
+
+### Talk Layer (`internal/talk/`)
+
+Two components:
+
+- **Client**: HTTP client for the claim-machinery-api REST API (list templates, get template, order claim)
+- **Conversation**: Builds AI prompts from template metadata and parses structured JSON responses
+
+### Gen Pipeline
+
+```
+Examples + Rulesets → BuildPrompt() → AI Provider → SaveOutput()
+```
+
+### Talk Pipeline
+
+```
+claim-machinery-api → BuildSystemPrompt() → AI Provider → ParseAIResponse() → OrderClaim() → SaveOutput()
+```
+
+### Interactive Menu (`internal/menu/`)
+
+Built with [Charmbracelet Huh](https://github.com/charmbracelet/huh) for terminal forms. Provides step-by-step configuration wizards for both `gen` and `talk` commands.
+
+## Dependencies
+
+| Dependency | Purpose |
+|------------|---------|
+| `github.com/spf13/cobra` | CLI framework |
+| `github.com/charmbracelet/huh` | Interactive terminal forms |
+| `github.com/charmbracelet/huh/spinner` | Loading spinners |
+| `github.com/pterm/pterm` | Terminal styling and tables |
+| `go.hein.dev/go-version` | Version information |

--- a/docs/gen-command.md
+++ b/docs/gen-command.md
@@ -1,0 +1,89 @@
+# Gen Command
+
+The `gen` command is the core code generation engine of k2n. It uses AI to generate configurations from code examples and optional rulesets.
+
+## Usage
+
+```bash
+k2n gen [flags]
+```
+
+## Flags
+
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `--instruction` | string | | Natural language instruction for AI (required) |
+| `--usecase` | string | | Context/technology for generation |
+| `--examples-dirs` | string | | Comma-separated directories with example files |
+| `--example-files` | string | | Comma-separated example file paths |
+| `--example-file-ext` | string | `.yaml,.tf` | Allowed file extensions |
+| `--ruleset-env-dir` | string | | Directory with environment rulesets |
+| `--ruleset-usecase-dir` | string | | Directory with use-case rulesets |
+| `--ruleset-env-files` | string | | Comma-separated environment ruleset files |
+| `--ruleset-usecase-files` | string | | Comma-separated use-case ruleset files |
+| `--destination` | string | stdout | Output: stdout, file path, or directory |
+| `--ai-provider` | string | openrouter | AI provider: `openrouter` or `gemini` |
+| `--ai-model` | string | | Model name for the AI provider |
+| `--ai-base-url` | string | | Base URL for OpenRouter API |
+| `--verbose`, `-v` | bool | false | Enable verbose output |
+| `--prompt-to-ai`, `-p` | bool | true | Send prompt to AI |
+
+## How It Works
+
+1. **Load examples** from directories or file paths
+2. **Load rulesets** (environment and use-case specific constraints)
+3. **Build prompt** combining role, rules, examples, and instruction
+4. **Call AI** provider with the constructed prompt
+5. **Output** the result to stdout, file, or directory
+
+## Examples
+
+### Generate with examples and rulesets
+
+```bash
+k2n gen \
+  --examples-dirs _examples/examples \
+  --ruleset-env-dir _examples/ruleset-env \
+  --ruleset-usecase-dir _examples/ruleset-runner \
+  --usecase crossplane \
+  --instruction "generate a runner claim for the dagger repository"
+```
+
+### Preview the prompt without calling AI
+
+```bash
+k2n gen \
+  --examples-dirs _examples/examples \
+  --usecase crossplane \
+  --instruction "generate a deployment for nginx" \
+  --verbose=true \
+  --prompt-to-ai=false
+```
+
+### Save output to a directory
+
+```bash
+k2n gen \
+  --examples-dirs _examples/examples \
+  --instruction "generate helm values for a web application" \
+  --destination /tmp/output/
+```
+
+## Examples and Rulesets
+
+### Examples
+
+Example files serve as few-shot learning material for the AI. Place your reference configurations in a directory and point to them with `--examples-dirs` or `--example-files`.
+
+### Rulesets
+
+Rulesets are constraint files that guide the AI generation:
+
+- **Environment rulesets** (`--ruleset-env-dir`): Environment-specific rules like versions, namespaces, or cluster configurations
+- **Use-case rulesets** (`--ruleset-usecase-dir`): Technology-specific rules like Crossplane runner specifications
+
+## Output Modes
+
+- **stdout** (default): Print generated output to terminal
+- **Single file**: `--destination /tmp/output.yaml` saves all content to one file
+- **Directory**: `--destination /tmp/output/` parses the AI output by `---` delimiter and saves each file separately

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,60 @@
+# k2n (/ˈkæf.kən/)
+
+An AI-powered CLI for generating Kubernetes and infrastructure configurations from examples and rulesets.
+
+## Overview
+
+k2n leverages artificial intelligence to transform natural language instructions into properly formatted configuration files, including:
+
+- Kubernetes manifests and CRDs
+- Crossplane claims and compositions
+- Helm values
+- Terraform configurations
+
+## Commands
+
+| Command | Description |
+|---------|-------------|
+| `k2n gen` | Generate configurations using AI based on examples and rulesets |
+| `k2n talk` | AI-powered conversational claim rendering via claim-machinery-api |
+| `k2n version` | Show version information |
+
+## Quick Start
+
+```bash
+# Set AI provider
+export AI_PROVIDER="openrouter"
+export AI_MODEL="openai/gpt-4"
+export AI_API_KEY="your-api-key"
+
+# Generate a claim from examples
+k2n gen \
+  --examples-dirs ./examples \
+  --usecase crossplane \
+  --instruction "generate a runner claim for the dagger repository"
+
+# Or talk to claim-machinery-api
+k2n talk \
+  --api-url http://localhost:8080 \
+  --instruction "I need a 50Gi volume in namespace production"
+```
+
+## Interactive Mode
+
+Run `k2n` without arguments to launch the interactive TUI menu with guided configuration for both `gen` and `talk` commands.
+
+## AI Providers
+
+k2n supports multiple AI providers:
+
+- **OpenRouter** - Access to multiple models (GPT-4, Deepseek, etc.)
+- **Google Gemini** - Google's Gemini API
+
+See [AI Providers](ai-providers.md) for configuration details.
+
+## Related Documentation
+
+- [Gen Command](gen-command.md)
+- [Talk Command](talk-command.md)
+- [AI Providers](ai-providers.md)
+- [Architecture](architecture.md)

--- a/docs/talk-command.md
+++ b/docs/talk-command.md
@@ -1,0 +1,113 @@
+# Talk Command
+
+The `talk` command provides AI-powered conversational claim rendering via the [claim-machinery-api](https://github.com/stuttgart-things/claim-machinery-api). Describe what you need in natural language, and k2n will select the right template, fill in the parameters, and render the claim.
+
+## Usage
+
+```bash
+k2n talk [flags]
+```
+
+## Flags
+
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `--api-url` | string | | Base URL of the claim-machinery-api (or `CLAIM_API_URL` env var) |
+| `--api-token` | string | | Auth token for claim-machinery-api (or `CLAIM_API_TOKEN` env var) |
+| `--instruction` | string | | Natural language description of the claim you want |
+| `--destination` | string | stdout | Output: stdout, file path, or directory |
+| `--ai-provider` | string | | AI provider: `openrouter` or `gemini` |
+| `--ai-model` | string | | AI model name |
+| `--ai-base-url` | string | | Base URL for OpenRouter API |
+| `--verbose`, `-v` | bool | false | Show prompts and raw AI responses |
+
+## How It Works
+
+```
+┌─────────┐     ┌──────────────────────┐     ┌─────────┐     ┌──────────────────────┐
+│  User    │────>│  k2n talk            │────>│   AI    │────>│  claim-machinery-api │
+│ "I need  │     │  1. Fetch templates  │     │ Select  │     │  Render claim YAML   │
+│  a 50Gi  │     │  2. Build prompt     │     │ template│     │  via KCL             │
+│  volume" │     │  3. Call AI          │     │ + params│     │                      │
+└─────────┘     └──────────────────────┘     └─────────┘     └──────────────────────┘
+```
+
+1. **Fetch templates** from the claim-machinery-api (`GET /api/v1/claim-templates`)
+2. **Build prompt** that includes all available templates with their parameter schemas
+3. **Call AI** to match the user's natural language instruction to a template and fill parameters
+4. **Parse AI response** to extract the selected template name and parameter values
+5. **Order the claim** via `POST /api/v1/claim-templates/{name}/order`
+6. **Output** the rendered YAML
+
+## Examples
+
+### Basic usage with OpenRouter
+
+```bash
+export AI_PROVIDER="openrouter"
+export AI_MODEL="openai/gpt-4"
+export AI_API_KEY="sk-or.."
+
+k2n talk \
+  --api-url http://localhost:8080 \
+  --instruction "I need a 50Gi persistent volume in namespace production with fast-ssd storage class"
+```
+
+### Using Gemini
+
+```bash
+export AI_PROVIDER="gemini"
+export AI_API_KEY="your-gemini-api-key"
+
+k2n talk \
+  --api-url http://localhost:8080 \
+  --instruction "create a harbor project for team-alpha"
+```
+
+### Save rendered claim to file
+
+```bash
+k2n talk \
+  --api-url http://localhost:8080 \
+  --instruction "give me a vsphere vm with 4 cpus and 8gb ram" \
+  --destination /tmp/vm-claim.yaml
+```
+
+### Verbose mode for debugging
+
+```bash
+k2n talk \
+  --api-url http://localhost:8080 \
+  --instruction "create a flux kustomization for the app repo" \
+  --verbose
+```
+
+This shows the full AI prompt, the raw AI response, and the parsed parameters before rendering.
+
+### Using environment variables
+
+```bash
+export CLAIM_API_URL="http://localhost:8080"
+export CLAIM_API_TOKEN="optional-auth-token"
+export AI_PROVIDER="openrouter"
+export AI_MODEL="openai/gpt-4"
+export AI_API_KEY="sk-or.."
+
+k2n talk --instruction "I need storage for my application"
+```
+
+## Environment Variables
+
+| Variable | Description |
+|----------|-------------|
+| `CLAIM_API_URL` | Base URL of the claim-machinery-api |
+| `CLAIM_API_TOKEN` | Optional auth token for the API |
+| `AI_API_KEY` | API key for the AI provider |
+| `AI_PROVIDER` | AI provider: `openrouter` or `gemini` |
+| `AI_MODEL` | Model name for the AI provider |
+| `AI_BASE_URL` | Custom base URL for OpenRouter |
+
+## Prerequisites
+
+- A running instance of [claim-machinery-api](https://github.com/stuttgart-things/claim-machinery-api) with loaded claim templates
+- An AI provider API key (OpenRouter or Gemini)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,12 @@
+site_name: k2n
+site_description: AI-powered CLI for generating Kubernetes and infrastructure configurations
+
+nav:
+  - Home: index.md
+  - Gen Command: gen-command.md
+  - Talk Command: talk-command.md
+  - AI Providers: ai-providers.md
+  - Architecture: architecture.md
+
+plugins:
+  - techdocs-core


### PR DESCRIPTION
## Summary
- Update README.md with talk command examples and feature overview
- Add `mkdocs.yml` for TechDocs integration (matching claim-machinery-api style)
- Add `catalog-info.yaml` for Backstage catalog registration
- Add `docs/` pages: index, gen-command, talk-command, ai-providers, architecture

Closes #28

## Test plan
- [ ] Verify mkdocs builds locally with `mkdocs build`
- [ ] Verify catalog-info.yaml is valid for Backstage import
- [ ] Review README examples for accuracy

🤖 Generated with [Claude Code](https://claude.com/claude-code)