### PR TITLE
fix: remove redundant newlines in fmt.Println calls

### DIFF
--- a/cmd/talk.go
+++ b/cmd/talk.go
@@ -138,7 +138,7 @@ claim in YAML format.`,
 		if talkVerbose {
 			fmt.Println("--- PROMPT ---")
 			fmt.Println(fullPrompt)
-			fmt.Println("--- END PROMPT ---\n")
+			fmt.Println("--- END PROMPT ---")
 		}
 
 		var aiOutput string
@@ -162,7 +162,7 @@ claim in YAML format.`,
 		if talkVerbose {
 			fmt.Println("--- AI RESPONSE ---")
 			fmt.Println(aiOutput)
-			fmt.Println("--- END AI RESPONSE ---\n")
+			fmt.Println("--- END AI RESPONSE ---")
 		}
 
 		// Step 3: Parse AI response
@@ -204,7 +204,7 @@ claim in YAML format.`,
 		}
 
 		// Step 5: Output the rendered YAML
-		fmt.Println("Claim rendered successfully!\n")
+		fmt.Println("\nClaim rendered successfully!")
 		if err := internal.SaveOutput(talkDestination, orderResp.Rendered); err != nil {
 			fmt.Fprintf(os.Stderr, "Error saving output: %v\n", err)
 			os.Exit(1)

--- a/internal/menu/interactive.go
+++ b/internal/menu/interactive.go
@@ -305,7 +305,7 @@ func showExecutionConfirmation(config *K2NConfig, rootCmd *cobra.Command) error 
 	}
 
 	if execute {
-		fmt.Println("\n🚀 Executing command...\n")
+		fmt.Println("\n🚀 Executing command...")
 		// Set the args and execute the gen command
 		os.Args = append([]string{"k2n", "gen"}, cmdArgs...)
 		return rootCmd.Execute()
@@ -458,7 +458,7 @@ func showTalkExecutionConfirmation(config *K2NConfig, rootCmd *cobra.Command) er
 	}
 
 	if execute {
-		fmt.Println("\n🚀 Executing command...\n")
+		fmt.Println("\n🚀 Executing command...")
 		os.Args = append([]string{"k2n", "talk"}, args...)
 		return rootCmd.Execute()
 	}


### PR DESCRIPTION
## Summary
- Fix 5 `go vet` warnings: `fmt.Println arg list ends with redundant newline`
- Affected files: `cmd/talk.go`, `internal/menu/interactive.go`

Closes #33

## Test plan
- [ ] `go vet ./...` passes cleanly
- [ ] CI build-test workflow passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)